### PR TITLE
Prevent changing all src Elements with new Upload

### DIFF
--- a/media.js
+++ b/media.js
@@ -27,7 +27,7 @@ window.fbControls.push(function media(controlClass) {
                     //Async read of the uploaded file and convert to a DateURI. Detect mimetype and adjust mimetype attribute and control Subtype
                     reader.addEventListener("load", function () {
                         const regexp = /^data:((?:\w+\/(?:(?!;).)+)?)/;
-                        const srcElement = input.closest('.frmb.stage-wrap').find('.fld-src');
+                        const srcElement = input.parent().parent().parent().find('.fld-src');
                         const dataUri = this.result;
                         const mediatype = dataUri.match(regexp);
                         if (null !== mediatype) {


### PR DESCRIPTION
with multiple media elements when uploading a media to one element all elements are updated with this new media.